### PR TITLE
Exclude files because 81914

### DIFF
--- a/tests/assets/conversion_exception.json
+++ b/tests/assets/conversion_exception.json
@@ -398,5 +398,22 @@
     "files": [
       "conv_cf4b9eae_edd0_4454_8291_33d678413833_67.docx"
     ]
+  },
+  "81914": {
+    "link": "81914",
+    "description": "",
+    "os": [],
+    "directions": [
+      "doc-md",
+      "docx-md",
+      "docxf-md"
+    ],
+    "files": [
+      "светильники ит.doc",
+      "Pizdariki.docx",
+      "Form W-9 (Request for TIN and Certification).docxf",
+      "Forms_Анкета_лизингополучателя_Final_2_1.docxf",
+      "Word2007RTFSpec9.docx"
+    ]
   }
 }


### PR DESCRIPTION
## Add files to conversion exceptions

- Bug **81914** (directions: `doc-md`, `docx-md`, `docxf-md`): added 5 files
  - `светильники ит.doc`
  - `Pizdariki.docx`
  - `Form W-9 (Request for TIN and Certification).docxf`
  - `Forms_Анкета_лизингополучателя_Final_2_1.docxf`
  - `Word2007RTFSpec9.docx`