### PR TITLE
Exclude files because 81941

### DIFF
--- a/tests/assets/conversion_exception.json
+++ b/tests/assets/conversion_exception.json
@@ -415,5 +415,14 @@
       "Forms_Анкета_лизингополучателя_Final_2_1.docxf",
       "Word2007RTFSpec9.docx"
     ]
+  },
+  "81941": {
+    "link": "81941",
+    "description": "",
+    "os": [],
+    "directions": [],
+    "files": [
+      "Report.odt"
+    ]
   }
 }


### PR DESCRIPTION
## Add files to conversion exceptions

- Bug **81941**: added `Report.odt`