### PR TITLE
Exclude files because 82013

### DIFF
--- a/tests/assets/conversion_exception.json
+++ b/tests/assets/conversion_exception.json
@@ -442,5 +442,16 @@
       "64-Использование функции ВЕБСЛУЖБА.xlsx",
       "8D_1.xlsx"
     ]
+  },
+  "82013": {
+    "link": "82013",
+    "description": "",
+    "os": [
+      "linux"
+    ],
+    "directions": [],
+    "files": [
+      "tabelle us-trade-balance1960-2008.ods"
+    ]
   }
 }


### PR DESCRIPTION
## Add files to conversion exceptions

- Bug **82013** (`os: linux`): added `tabelle us-trade-balance1960-2008.ods`